### PR TITLE
Feature/9

### DIFF
--- a/HierarchyGeneratorClient/.dockerignore
+++ b/HierarchyGeneratorClient/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+/dist
+.vscode
+.git
+.gitignore
+Dockerfile
+README.md

--- a/HierarchyGeneratorClient/Dockerfile
+++ b/HierarchyGeneratorClient/Dockerfile
@@ -19,6 +19,9 @@ RUN npm run build
 # Set up a minimal server to serve the built app using Nginx
 FROM nginx:alpine
 
+# Copy the custom nginx.conf to the appropriate location in the Nginx container
+COPY nginx.conf /etc/nginx/nginx.conf
+
 # Copy the built app from the previous stage into the Nginx container
 COPY --from=build /app/dist /usr/share/nginx/html
 

--- a/HierarchyGeneratorClient/Dockerfile
+++ b/HierarchyGeneratorClient/Dockerfile
@@ -1,0 +1,29 @@
+# Build the React app using Node.js
+FROM node:22 AS build
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the package.json and package-lock.json to install dependencies first
+COPY package*.json ./
+
+# Install the project dependencies
+RUN npm install
+
+# Copy the rest of the app's files into the container
+COPY . .
+
+# Build the app
+RUN npm run build
+
+# Set up a minimal server to serve the built app using Nginx
+FROM nginx:alpine
+
+# Copy the built app from the previous stage into the Nginx container
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Expose the default Nginx port
+EXPOSE 80
+
+# Start the Nginx server
+CMD ["nginx", "-g", "daemon off;"]

--- a/HierarchyGeneratorClient/nginx.conf
+++ b/HierarchyGeneratorClient/nginx.conf
@@ -1,0 +1,30 @@
+# The main Nginx configuration block
+events {
+    worker_connections 1024;  # Defines the maximum number of simultaneous connections per worker
+}
+
+http {
+    include       /etc/nginx/mime.types;  # Make sure mime.types is included
+    default_type  application/octet-stream;  # Default type for unknown files
+    # Main server block for handling requests
+    server {
+        listen 80;
+        server_name localhost;
+
+        # Proxy API requests to the backend API service
+        location /backend/ {
+            proxy_pass http://api:80/;
+            rewrite ^/backend(/.*)$ $1 break;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            root /usr/share/nginx/html;
+            try_files $uri $uri/ /index.html;
+        }
+
+    }
+}

--- a/HierarchyGeneratorClient/src/App.jsx
+++ b/HierarchyGeneratorClient/src/App.jsx
@@ -7,7 +7,7 @@ function App() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch("/api/hierarchy")
+    fetch("/backend/api/hierarchy")
       .then((response) => response.json())
       .then((data) => setHierarchies(data))
       .catch((err) => {

--- a/HierarchyGeneratorClient/vite.config.js
+++ b/HierarchyGeneratorClient/vite.config.js
@@ -10,10 +10,11 @@ export default defineConfig({
   ],
   server: {
     proxy: {
-      "/api": {
+      "/backend": {
         target: "http://localhost:1337",
         changeOrigin: true,
         secure: false,
+        rewrite: (path) => path.replace(/^\/backend/, '')
       },
     },
   },

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Run the following command in this folder:
 
     docker-compose up -d
 
-Go to [API Swagger](http://localhost:1337/swagger/index.html)
+Open [Hierarchy Generator App](http://localhost:8080)
+
+Backend is available here: [API Swagger](http://localhost:8080/backend/swagger/index.html)
 
 ## How to stop the application?
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,13 @@
 services:
+ client:
+  container_name: HierarchyGeneratorClient
+  build:
+      context: HierarchyGeneratorClient
+      dockerfile: Dockerfile
+  depends_on:
+      - api
+  ports:
+      - "8080:80"
  api:
   container_name: HierarchyGeneratorApi
   build:


### PR DESCRIPTION
Containerized the frontend client and put it in the docker-compose. The client can still be run locally as well using the vite developer server. Now database, backend and frontend are all running in docker inside one docker-compose file. The whole application can start with the command: 

```
docker-compose up -d
```
The biggest challenge with this pull request was to get the frontend inside docker to connect to the backend without CORS issues. The solution was to proxy the traffic towards the backend using the same nginx that serves the react frontend.