### PR TITLE
#79 Added validation on name field for POST hierarchies

### DIFF
--- a/HierarchyGeneratorApi/DTOs/CreateHierarchyParameters.cs
+++ b/HierarchyGeneratorApi/DTOs/CreateHierarchyParameters.cs
@@ -1,9 +1,13 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace HierarchyGeneratorApi.DTOs;
 
 public class CreateHierarchyParameters
 {
+    [Required(ErrorMessage = "Name is required.")]
+    [MinLength(1, ErrorMessage = "Name cannot be empty.")]
+    [MaxLength(200, ErrorMessage = "Name cannot be longer than 200.")]
     public string Name { get; set; }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/Test/IntegrationTests/HierarchyApiTests.cs
+++ b/Test/IntegrationTests/HierarchyApiTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text;
+using System.Xml.Linq;
 using Newtonsoft.Json;
 
 namespace MyIntegrationTests
@@ -51,8 +52,58 @@ namespace MyIntegrationTests
 
             var response = await _client.PostAsync("/api/hierarchy", content);
 
-            response.EnsureSuccessStatusCode();
             Assert.Equal(System.Net.HttpStatusCode.NoContent, response.StatusCode);
+        }
+
+
+        [Fact]
+        public async Task PostHierarchyWithoutBearerToken_ShouldReturnUnauthorized()
+        {
+            var postData = new
+            {
+                Name = "TestHierarchy created by xUnit"
+            };
+
+            var content = new StringContent(JsonConvert.SerializeObject(postData), Encoding.UTF8, "application/json");
+
+            var response = await _client.PostAsync("/api/hierarchy", content);
+
+            Assert.Equal(System.Net.HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+
+        [Fact]
+        public async Task PostHierarchyWithEmptytName_ShouldReturnBadRequest()
+        {
+            SetBearerToken();
+
+            var postData = new
+            {
+                Name = ""
+            };
+
+            var content = new StringContent(JsonConvert.SerializeObject(postData), Encoding.UTF8, "application/json");
+
+            var response = await _client.PostAsync("/api/hierarchy", content);
+
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task PostHierarchyWithNameLongerThan200chars_ShouldReturnBadRequest()
+        {
+            SetBearerToken();
+
+            var postData = new
+            {
+                Name = "abcdefghijklmnopqrstuvxyzåäöabcdefghijklmnopqrstuvxyzåäöabcdefghijklmnopqrstuvxyzåäöabcdefghijklmnopqrstuvxyzåäöabcdefghijklmnopqrstuvxyzåäöabcdefghijklmnopqrstuvxyzåäöabcdefghijklmnovxyzåäöabcdefghij1"
+            };
+
+            var content = new StringContent(JsonConvert.SerializeObject(postData), Encoding.UTF8, "application/json");
+
+            var response = await _client.PostAsync("/api/hierarchy", content);
+
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
         }
 
         [Fact]


### PR DESCRIPTION
Added validation on name field for POST hierarchies, requiring it to be 1 and 200 chars. Also added integration tests to test this.