### PR TITLE
#103 created a new healthz endpoint in the api, which returns 200 OK

### DIFF
--- a/HierarchyGeneratorApi/Controllers/HealthController.cs
+++ b/HierarchyGeneratorApi/Controllers/HealthController.cs
@@ -1,0 +1,29 @@
+﻿using HierarchyGeneratorApi.Models;
+using HierarchyGeneratorApi.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HierarchyGeneratorApi.Controllers;
+
+public class HealthController : ControllerBase
+{
+    private readonly IHierarchyService _hierarchyService;
+    public HealthController(IHierarchyService hierarchyService)
+    {
+        _hierarchyService = hierarchyService;
+    }
+
+    [HttpGet("/healthz")]
+    public async Task<IActionResult> Get()
+    {
+        try
+        {
+            List<Hierarchy> hierarchies = _hierarchyService.GetHierarchies();
+            return Ok("OK");
+        } catch (MySqlConnector.MySqlException)
+        {
+            return StatusCode(503, "Database is not ready or not working");
+        } catch {
+            return StatusCode(503, "API is not ready or not healthy");
+        }
+    }
+}

--- a/HierarchyGeneratorApi/Controllers/HierarchyController.cs
+++ b/HierarchyGeneratorApi/Controllers/HierarchyController.cs
@@ -3,8 +3,6 @@ using HierarchyGeneratorApi.Models;
 using HierarchyGeneratorApi.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Serilog;
-using System.Data.Entity.Hierarchy;
 
 namespace HierarchyGeneratorApi.Controllers;
 

--- a/HierarchyGeneratorApi/Dockerfile
+++ b/HierarchyGeneratorApi/Dockerfile
@@ -17,6 +17,8 @@ RUN dotnet publish -c Release -o /publish
 # Use a smaller runtime image for production
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
 
+RUN apt-get update && apt-get install -y curl
+
 # Set the working directory
 WORKDIR /app
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,7 +5,8 @@ services:
       context: HierarchyGeneratorClient
       dockerfile: Dockerfile
   depends_on:
-      - api
+      api:
+        condition: service_healthy
   ports:
       - "8080:80"
  api:
@@ -18,6 +19,12 @@ services:
         condition: service_healthy
   ports:
       - "1337:80"
+  healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
  db:
   container_name: HierarchyGeneratorDatabase
   build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   platform: linux/amd64
   image: alexandraisaksson/hierarchy-generator-client:latest
   depends_on:
-      - api
+      api:
+        condition: service_healthy
   ports:
       - "8080:80"
  api:
@@ -16,6 +17,12 @@ services:
         condition: service_healthy
   ports:
       - "1337:80"
+  healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
  db:
   container_name: HierarchyGeneratorDatabase
   platform: linux/amd64


### PR DESCRIPTION
#103 created a new healthz endpoint in the api, which returns 200 OK if the application has started and can read from the database.

Also added healthcheck to the api in the docker-compose, using curl that calls the new healthz endpoint for up to 3 minutes and 30 seconds. It tries every 10 seconds and a soon as it gets a OK, it continues to start up the client. After 3 minutes and 30 seconds have passed without a OK from healthz, the docker-compose stops trying and reports an error.

Added curl to the API docker image, which is used in the health check.